### PR TITLE
Bugfix on the PageSizeChangedEvent callback so it doesn't get triggered more then it needs and it remembers the PageSize set internally

### DIFF
--- a/GrabasUI/Components/DataGrid.razor.cs
+++ b/GrabasUI/Components/DataGrid.razor.cs
@@ -8,8 +8,8 @@ namespace GrabaUIPackage.Components
 	{
 		private int totalPages;
 		private int currentPage;
-		private int pagerSize = 7;
 		private int[]? pagingNumbers;
+		private int internalPageSize;
 
 		[Parameter]
 		public RenderFragment? ChildContent { get; set; }
@@ -62,15 +62,15 @@ namespace GrabaUIPackage.Components
 		[Parameter]
 		public int PageSize
 		{
-			get { return pagerSize; }
+			get => internalPageSize;
 			set
 			{
-				if (EqualityComparer<int>.Default.Equals(pagerSize, value))
+				if (EqualityComparer<int>.Default.Equals(internalPageSize, value))
 				{
 					return;
 				}
 
-				pagerSize = value;
+				internalPageSize = value;
 				_ = OnPageSizeChanged.InvokeAsync(new PageSizeChangedEventArgs { PageSize = value });
 			}
 		}
@@ -200,9 +200,12 @@ namespace GrabaUIPackage.Components
 			if (PageSizeOptions == null)
 			{
 				PageSizeOptions = [10, 20, 30];
-				PageSize = 10;
+				if (internalPageSize == 0) // Only set if not already set
+				{
+					PageSize = 10;
+				}
 			}
-			else
+			else if (internalPageSize == 0) // Only set if not already set
 			{
 				PageSize = PageSizeOptions.FirstOrDefault();
 			}
@@ -331,27 +334,28 @@ namespace GrabaUIPackage.Components
 
 		private void CalculatePagingNumbers(int currentPage, int totalRows)
 		{
+			var defaultPagerSize = 7; // Default pager size moved here
 			totalPages = (int)Math.Ceiling(totalRows / (decimal)PageSize);
 
-			if (totalPages <= pagerSize)
+			if (totalPages <= defaultPagerSize)
 			{
 				pagingNumbers = [.. Enumerable.Range(1, totalPages)];
 			}
 			else
 			{
-				int middlePosition = pagerSize / 2;
+				int middlePosition = defaultPagerSize / 2;
 
 				if (currentPage < middlePosition + 1)
 				{
-					pagingNumbers = [.. Enumerable.Range(1, pagerSize - 1), .. new[] { totalPages }];
+					pagingNumbers = [.. Enumerable.Range(1, defaultPagerSize - 1), .. new[] { totalPages }];
 				}
 				else if (currentPage > totalPages - middlePosition)
 				{
-					pagingNumbers = [.. new[] { 1 }, .. Enumerable.Range(totalPages - pagerSize + 2, pagerSize - 1)];
+					pagingNumbers = [.. new[] { 1 }, .. Enumerable.Range(totalPages - defaultPagerSize + 2, defaultPagerSize - 1)];
 				}
 				else
 				{
-					pagingNumbers = [.. new[] { 1 }, .. Enumerable.Range(currentPage - middlePosition + 1, pagerSize - 2), totalPages];
+					pagingNumbers = [.. new[] { 1 }, .. Enumerable.Range(currentPage - middlePosition + 1, defaultPagerSize - 2), totalPages];
 				}
 			}
 		}

--- a/GrabasUI/GrabasUI.csproj
+++ b/GrabasUI/GrabasUI.csproj
@@ -11,7 +11,7 @@
 		<PackageId>GrabaUIPackage</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-		<Version>1.0.3</Version>
+		<Version>1.0.4</Version>
 		<Authors>Antonio Glešić</Authors>
 		<Company></Company>
 		<Description>My blazor UI package library</Description>


### PR DESCRIPTION
Bugfix on the PageSizeChangedEvent callback so it doesn't get triggered more then it needs and it remembers the PageSize set internally

Refactor DataGrid paging logic and properties

Replaced `pagerSize` with `internalPageSize` in the
`DataGrid<TItem>` class. Updated the `PageSize` property
to use `internalPageSize` and set a default value of 10
only if `internalPageSize` is zero. The paging number
calculation now uses a default pager size of 7, ensuring
consistent paging logic throughout the component.