### PR TITLE
Add FrontendPagination to DataGrid component

### DIFF
--- a/GrabasUI/Components/DataGrid.razor.cs
+++ b/GrabasUI/Components/DataGrid.razor.cs
@@ -24,6 +24,9 @@ namespace GrabaUIPackage.Components
 		public int? RowCount { get; set; }
 
 		[Parameter]
+		public bool? FrontendPagination { get; set; } = false;
+
+		[Parameter]
 		public EventCallback<PageChangedEventArgs> OnPageChanged { get; set; }
 
 		[Parameter]
@@ -255,6 +258,12 @@ namespace GrabaUIPackage.Components
 			else
 			{
 				ItemList = Items?.Skip((currentPage - 1) * PageSize).Take(PageSize);
+
+				if (FrontendPagination.HasValue && FrontendPagination.Value)
+				{
+					await OnPageChanged.InvokeAsync(new PageChangedEventArgs() { CurrentPage = currentPage, PageSize = PageSize });
+					await OnPageSizeChanged.InvokeAsync(new PageSizeChangedEventArgs() { PageSize = PageSize });
+				}
 			}
 
 			CalculatePagingNumbers(currentPage, RowCount ?? (Items != null ? Items.Count() : 0));

--- a/GrabasUI/GrabasUI.csproj
+++ b/GrabasUI/GrabasUI.csproj
@@ -11,7 +11,7 @@
 		<PackageId>GrabaUIPackage</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-		<Version>1.0.4</Version>
+		<Version>1.1.0</Version>
 		<Authors>Antonio Glešić</Authors>
 		<Company></Company>
 		<Description>My blazor UI package library</Description>


### PR DESCRIPTION
Add FrontendPagination to DataGrid component

Introduced a new optional parameter `FrontendPagination` to the `DataGrid` component, allowing users to enable or disable frontend pagination. Updated the component logic to invoke `OnPageChanged` and `OnPageSizeChanged` event callbacks based on the `FrontendPagination` value. Also, incremented the version number in `GrabasUI.csproj` from `1.0.4` to `1.1.0` for the new release.